### PR TITLE
Add app transfer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@pokt-foundation/pocketjs-provider": "^2.1.0",
-        "@pokt-foundation/pocketjs-relayer": "^2.1.0",
-        "@pokt-foundation/pocketjs-signer": "^2.1.0",
-        "@pokt-foundation/pocketjs-transaction-builder": "^2.1.0",
-        "@pokt-foundation/pocketjs-utils": "^2.1.0"
+        "@pokt-foundation/pocketjs-provider": "^2.2.1",
+        "@pokt-foundation/pocketjs-relayer": "^2.2.1",
+        "@pokt-foundation/pocketjs-signer": "^2.2.1",
+        "@pokt-foundation/pocketjs-transaction-builder": "^2.2.1",
+        "@pokt-foundation/pocketjs-utils": "^2.2.1"
       },
       "devDependencies": {
         "@types/node": "^20.2.5"
@@ -3404,6 +3404,14 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -3675,9 +3683,9 @@
       ]
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "engines": {
         "node": ">= 16"
       },
@@ -3812,29 +3820,30 @@
       }
     },
     "node_modules/@pokt-foundation/pocketjs-abstract-provider": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-abstract-provider/-/pocketjs-abstract-provider-2.1.3.tgz",
-      "integrity": "sha512-6LL2XaAragij2RV6t2CEJLC1spO6oDBBIWFWDvV4jjgwahgWHmbdxHtrg06gf0Vit+Wv0iOiYYcXTxwYLtS9yw=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-abstract-provider/-/pocketjs-abstract-provider-2.2.1.tgz",
+      "integrity": "sha512-5RTft2v0uSF4MvYS48lLbKTAhqeZ1ZW/F8wcV8huEQYbBeEOSeFZOsVoWzAuzU6uqdX1HRE680JAfhqMeSgzGg=="
     },
     "node_modules/@pokt-foundation/pocketjs-provider": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-provider/-/pocketjs-provider-2.1.3.tgz",
-      "integrity": "sha512-VKIb5o+Luc8mY4GpENKFJBp23/R2BFZ+d8Knf2BADtihWVjuiOSmlP686di8cQVaZbkzmdYkGK06sLW8dlORuA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-provider/-/pocketjs-provider-2.2.1.tgz",
+      "integrity": "sha512-RNjQrU5+KoVaY/yJS81bNnK71JMF1mHjKVOYLCQXfigKO8x9SQhCeHAelNMHKilxFsorPYGyWdwA/0L+zA2sGA==",
       "dependencies": {
-        "@pokt-foundation/pocketjs-abstract-provider": "2.1.3",
+        "@pokt-foundation/pocketjs-abstract-provider": "2.2.1",
         "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
         "debug": "^4.3.3",
-        "undici": "^5.0.0"
+        "undici": "^5.26.2"
       }
     },
     "node_modules/@pokt-foundation/pocketjs-relayer": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-relayer/-/pocketjs-relayer-2.1.3.tgz",
-      "integrity": "sha512-l3UZIz/Ja++bfzsKEJsNlDFaR4ZH0MRdzIeIkMJcHoacMm3UjNC/vKdzhIp0pG3trNMf0wzUGNGq0S8lgrcQPw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-relayer/-/pocketjs-relayer-2.2.1.tgz",
+      "integrity": "sha512-MnvTXo3KXEDEa5LIVL7aMcFjiiQscEowKA0WJXGG/1cjN+x+LR0bCiuXzllqlvx6Rn9bele6YO41iw9yTly4hQ==",
       "dependencies": {
-        "@pokt-foundation/pocketjs-abstract-provider": "2.1.3",
-        "@pokt-foundation/pocketjs-provider": "2.1.3",
-        "@pokt-foundation/pocketjs-signer": "2.1.3",
+        "@pokt-foundation/pocketjs-abstract-provider": "2.2.1",
+        "@pokt-foundation/pocketjs-provider": "2.2.1",
+        "@pokt-foundation/pocketjs-signer": "2.2.1",
         "debug": "^4.3.3",
         "isomorphic-webcrypto": "^2.3.8",
         "js-sha256": "^0.9.0",
@@ -3842,14 +3851,12 @@
       }
     },
     "node_modules/@pokt-foundation/pocketjs-signer": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-signer/-/pocketjs-signer-2.1.3.tgz",
-      "integrity": "sha512-hkPrjlMPxZ9leWXaPX+MK3BTPUthP7RqsQQXiqh4Jb8ETMoS8xRxfOEdUB1wMSlQfqUCLPouwp7LU607Z8ZHGQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-signer/-/pocketjs-signer-2.2.1.tgz",
+      "integrity": "sha512-CyGIb3tC7M+n93QiccKRXC8m86hVo7GC0QiXzjzspZtef8dEREPB8Ags/jDTECgH9YAkvEpyfpLDZDJC3v7Xcg==",
       "dependencies": {
         "@noble/ed25519": "^1.5.3",
-        "@pokt-foundation/pocketjs-abstract-provider": "2.1.3",
-        "@pokt-foundation/pocketjs-provider": "2.1.3",
-        "@pokt-foundation/pocketjs-utils": "2.1.3",
+        "@pokt-foundation/pocketjs-utils": "2.2.1",
         "buffer": "^6.0.3",
         "debug": "^4.3.3",
         "isomorphic-crypto": "^3.0.0",
@@ -3858,32 +3865,32 @@
       }
     },
     "node_modules/@pokt-foundation/pocketjs-transaction-builder": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-transaction-builder/-/pocketjs-transaction-builder-2.1.3.tgz",
-      "integrity": "sha512-k8sBUsCCj/qSovKCFvgF/uMjJC859d2k5jfOC6e6FQfAc5L4wNNAwYIBVMNCglWLd/jXMWvmmv0yEzjWjh2LsA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-transaction-builder/-/pocketjs-transaction-builder-2.2.1.tgz",
+      "integrity": "sha512-zEK1ILWkAqQHBscFdBhmLpnQ6y/T0Bq4SieHSMHmLIahFF/aHv709ZjKBBYUQ401VfuiSX/oSZ7RgDkfaJu0zA==",
       "dependencies": {
-        "@pokt-foundation/pocketjs-abstract-provider": "2.1.3",
-        "@pokt-foundation/pocketjs-signer": "2.1.3",
-        "@pokt-foundation/pocketjs-types": "2.1.3",
-        "@pokt-foundation/pocketjs-utils": "2.1.3",
+        "@pokt-foundation/pocketjs-abstract-provider": "2.2.1",
+        "@pokt-foundation/pocketjs-signer": "2.2.1",
+        "@pokt-foundation/pocketjs-types": "2.2.1",
+        "@pokt-foundation/pocketjs-utils": "2.2.1",
         "@pokt-network/amino-js": "^0.7.5-alpha.1",
         "@tendermint/belt": "^0.3.0",
         "buffer": "^6.0.3",
         "long": "^5.2.0",
-        "protobufjs": "6.8.8",
-        "ts-proto": "^1.110.4",
+        "protobufjs": "6.11.4",
+        "ts-proto": "^1.167.8",
         "varint": "^6.0.0"
       }
     },
     "node_modules/@pokt-foundation/pocketjs-types": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-types/-/pocketjs-types-2.1.3.tgz",
-      "integrity": "sha512-9AlnNigM8T9qi9dXk0AQQCzq/NPrSXamOBJeEkUK7pTzkAQTzw7jYgGKVFDvnM/AwfEp4CRc26PFCXuZG3zV7A=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-types/-/pocketjs-types-2.2.1.tgz",
+      "integrity": "sha512-2UsDKOlMaEN3Ezq2sKZqY5NlcNO/tvH6D4PoQKVwPTtQj1GdigLMUel+c2yfyNppsWo7qJMOUie4g2RTHR294w=="
     },
     "node_modules/@pokt-foundation/pocketjs-utils": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-utils/-/pocketjs-utils-2.1.3.tgz",
-      "integrity": "sha512-QcrKr/HNzCmn1byLPYD2fo3PObhhvOWbsp7l/DekMpw9hbDtXOIAQzQTCxxhu4P5J30+xIr07xaMvcDdhNha7w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@pokt-foundation/pocketjs-utils/-/pocketjs-utils-2.2.1.tgz",
+      "integrity": "sha512-6jQybV0rliG9+6ZkTzR1QTWFZ/JN3xRxe7ky1bcgS+KeC0V8TSSAaUCd1kyJBf5tQ9uP6S2+ADSDczoegjPVww==",
       "dependencies": {
         "@noble/hashes": "^1.0.0",
         "hex-lite": "^1.5.0",
@@ -6615,17 +6622,6 @@
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
       "optional": true,
       "peer": true
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
-      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -12437,9 +12433,9 @@
       "peer": true
     },
     "node_modules/protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -12452,19 +12448,14 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
         "long": "^4.0.0"
       },
       "bin": {
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
       }
-    },
-    "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/protobufjs/node_modules/long": {
       "version": "4.0.0",
@@ -13648,14 +13639,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -14186,21 +14169,21 @@
       "peer": true
     },
     "node_modules/ts-poet": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.6.0.tgz",
-      "integrity": "sha512-4vEH/wkhcjRPFOdBwIh9ItO6jOoumVLRF4aABDX5JSNEubSqwOulihxQPqai+OkuygJm3WYMInxXQX4QwVNMuw==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.8.1.tgz",
+      "integrity": "sha512-uqdjJGnQQjBwUeJggUi4o8VhRjUmEdRfo+uqEL+K8w7mKPfLUFAQ1dSURyhFfbA4T/cWPh8Xa7iBgO7jJNsc1A==",
       "dependencies": {
-        "dprint-node": "^1.0.7"
+        "dprint-node": "^1.0.8"
       }
     },
     "node_modules/ts-proto": {
-      "version": "1.158.0",
-      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.158.0.tgz",
-      "integrity": "sha512-t5XcKYvdeeeinP4zBA+YXzRANMXacxPzqhs7hsmnD9RxfP1L+Ip858ii9Zdkp/UYW58N3q4wJKLdZfvnBmAk9w==",
+      "version": "1.171.0",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-1.171.0.tgz",
+      "integrity": "sha512-NMwiqCixlk6MZ3TAIpVQUuWwUktCXhoP+07V7D7Eo2IlEwulZucOGrU82toHhPL/QTd+oMBM2RDeQk9qs8+ZEQ==",
       "dependencies": {
         "case-anything": "^2.1.13",
         "protobufjs": "^7.2.4",
-        "ts-poet": "^6.5.0",
+        "ts-poet": "^6.7.0",
         "ts-proto-descriptors": "1.15.0"
       },
       "bin": {
@@ -14217,9 +14200,9 @@
       }
     },
     "node_modules/ts-proto-descriptors/node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -14240,9 +14223,9 @@
       }
     },
     "node_modules/ts-proto/node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -14364,11 +14347,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.25.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.25.2.tgz",
-      "integrity": "sha512-tch8RbCfn1UUH1PeVCXva4V8gDpGAud/w0WubD6sHC46vYQ3KDxL+xv1A2UxK0N6jrVedutuPHxe1XIoqerwMw==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
-        "busboy": "^1.6.0"
+        "@fastify/busboy": "^2.0.0"
       },
       "engines": {
         "node": ">=14.0"

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "main": "src/index.ts",
   "license": "MIT",
   "dependencies": {
-    "@pokt-foundation/pocketjs-provider": "^2.1.0",
-    "@pokt-foundation/pocketjs-relayer": "^2.1.0",
-    "@pokt-foundation/pocketjs-signer": "^2.1.0",
-    "@pokt-foundation/pocketjs-transaction-builder": "^2.1.0",
-    "@pokt-foundation/pocketjs-utils": "^2.1.0"
+    "@pokt-foundation/pocketjs-provider": "^2.2.1",
+    "@pokt-foundation/pocketjs-relayer": "^2.2.1",
+    "@pokt-foundation/pocketjs-signer": "^2.2.1",
+    "@pokt-foundation/pocketjs-transaction-builder": "^2.2.1",
+    "@pokt-foundation/pocketjs-utils": "^2.2.1"
   },
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "start": "tsc && node dist/index.js"
+    "start": "tsc && node dist/index.js",
+    "generate-new-keys": "tsc && node dist/generate-keys.js"
   },
   "devDependencies": {
     "@types/node": "^20.2.5"

--- a/src/common/ask_question.ts
+++ b/src/common/ask_question.ts
@@ -1,0 +1,15 @@
+import * as readline from "readline";
+
+/**
+ * Prompts the user with a question and waits for the answer.
+ *
+ * @param {string} question - The question to ask.
+ * @returns {Promise<string>} A promise that resolves to the user's answer.
+ */
+export function askQuestion(rl: readline.Interface, question: string): Promise<string> {
+    return new Promise((resolve) => {
+        rl.question(question, (answer) => {
+            resolve(answer);
+        });
+    });
+}

--- a/src/generate-keys.ts
+++ b/src/generate-keys.ts
@@ -1,11 +1,6 @@
 import * as fs from 'fs';
 import * as readline from 'readline';
-
-import {JsonRpcProvider} from "@pokt-foundation/pocketjs-provider";
-
 import * as Path from "path";
-import {setPoktProvider} from "./di";
-import {appStakeRetry, appUnstakeRetry} from "./pokt/appStakeTxs";
 import {askQuestion} from "./common/ask_question";
 import {KeyManager} from "@pokt-foundation/pocketjs-signer";
 
@@ -18,16 +13,15 @@ const rl = readline.createInterface({
 
 async function main() {
     const appStakeAmount = await askQuestion(rl, 'How many app stakes to generate?: ');
-
     let csvOutput = 'privateKey\n'
-
     const privateKeys: string[] = []
     for(let i = 0; i < parseInt(appStakeAmount); i++) {
         const km = await KeyManager.createRandom()
         privateKeys.push(km.getPrivateKey())
     }
     csvOutput += privateKeys.join("\n")
-    fs.writeFileSync(csvOutput, Path.join(__dirname, `../input/new-app-private-keys-${new Date().toISOString()}.csv`.replace(/:/g,"_"), csvOutput, 'utf8'))
+    const outputPath = Path.join(__dirname, `../input/new-app-private-keys-${new Date().toISOString()}.csv`.replace(/:/g,"_"))
+    fs.writeFileSync(outputPath, csvOutput, 'utf8')
     rl.close()
 }
 

--- a/src/generate-keys.ts
+++ b/src/generate-keys.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs';
+import * as readline from 'readline';
+
+import {JsonRpcProvider} from "@pokt-foundation/pocketjs-provider";
+
+import * as Path from "path";
+import {setPoktProvider} from "./di";
+import {appStakeRetry, appUnstakeRetry} from "./pokt/appStakeTxs";
+import {askQuestion} from "./common/ask_question";
+import {KeyManager} from "@pokt-foundation/pocketjs-signer";
+
+
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+});
+
+
+async function main() {
+    const appStakeAmount = await askQuestion(rl, 'How many app stakes to generate?: ');
+
+    let csvOutput = 'privateKey\n'
+
+    const privateKeys: string[] = []
+    for(let i = 0; i < parseInt(appStakeAmount); i++) {
+        const km = await KeyManager.createRandom()
+        privateKeys.push(km.getPrivateKey())
+    }
+    csvOutput += privateKeys.join("\n")
+    fs.writeFileSync(csvOutput, Path.join(__dirname, `../input/new-app-private-keys-${new Date().toISOString()}.csv`.replace(/:/g,"_"), csvOutput, 'utf8'))
+    rl.close()
+}
+
+
+main().catch((error) => {
+    console.error('An error occurred:', error);
+    rl.close();
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ import {JsonRpcProvider} from "@pokt-foundation/pocketjs-provider";
 
 import * as Path from "path";
 import {setPoktProvider} from "./di";
-import {appStakeRetry, appUnstakeRetry} from "./pokt/appStakeTxs";
+
+import {askQuestion} from "./common/ask_question";
+import {sendAppStakeTransfer} from "./pokt/appStakeTxs";
 
 
 const rl = readline.createInterface({
@@ -19,7 +21,7 @@ const oldAppPrivateKeysPath = Path.join(__dirname, "../input/old-app-private-key
 const newAppPrivateKeysPath = Path.join(__dirname, "../input/new-app-private-keys.csv")
 
 async function main() {
-    const rpcProviderUrl = await askQuestion('Enter your POKT RPC Provider URL: ');
+    const rpcProviderUrl = await askQuestion(rl, 'Enter your POKT RPC Provider URL: ');
 
     const inputFiles = [oldAppPrivateKeysPath, newAppPrivateKeysPath]
     for (const f of inputFiles) {
@@ -32,8 +34,8 @@ async function main() {
     const unstakePrivateKeys = getAppPrivateKeysFromCSV(oldAppPrivateKeysPath)
     const newAppStakePrivateKeys = getAppPrivateKeysFromCSV(newAppPrivateKeysPath)
 
-    if(unstakePrivateKeys.length != newAppStakePrivateKeys.length) {
-        throw new Error(`${unstakePrivateKeys} old app stakes does not match the replacement of ${newAppStakePrivateKeys} new app stakes`)
+    if (unstakePrivateKeys.length != newAppStakePrivateKeys.length) {
+        throw new Error(`${unstakePrivateKeys.length} old app stakes does not match the replacement of ${newAppStakePrivateKeys.length} new app stakes`)
     }
 
     console.log('')
@@ -41,9 +43,9 @@ async function main() {
     console.log(`RPC Provider: ${rpcProviderUrl}`)
     console.log('')
 
-    const confirm = await askQuestion(`Does this seem correct? Confirm by typing yes: `)
+    const confirm = await askQuestion(rl, `Does this seem correct? Confirm by typing yes: `)
 
-    if(!["y", "yes"].includes(confirm)) {
+    if (!["y", "yes"].includes(confirm)) {
         throw new Error(`User confirmation failed, user answered with ${confirm}`)
     }
 
@@ -54,144 +56,121 @@ async function main() {
     }));
 
     // handle stakes
-    if(!await handleAppStakeAction('unstake', unstakePrivateKeys)) {
+    if (!await handleAppStakeTransfers(unstakePrivateKeys, unstakePrivateKeys)) {
         throw new Error("Failed to stake all apps, try running the script again!")
 
+        console.log("App stakes successfully rotated")
+        rl.close()
     }
 
-    if(!await handleAppStakeAction('stake', newAppStakePrivateKeys)) {
-        throw new Error("Failed to stake all apps, try running the script again!")
-    }
+    /**
+     * Handles the app stake transfers
+     * Processes the keys in batches and generates a CSV report of the results.
+     *
+     * @param {string[]} oldPrivateKeys - Array of app private keys to transfer from
+     * @param {string[]} newPrivateKeys - Array of app private keys to transfer to
+     * @returns {Promise<boolean>} Returns true if all actions are successful, false otherwise.
+     */
+    async function handleAppStakeTransfers(oldPrivateKeys: string[], newPrivateKeys: string[]) {
 
-    console.log("App stakes successfully rotated")
-    rl.close()
-}
+        const responses: {
+            response: string,
+            success: boolean
+        }[] = [];
 
-/**
- * Handles the staking or unstaking actions for given app private keys.
- * Processes the keys in batches and generates a CSV report of the results.
- *
- * @param {('stake' | 'unstake')} action - The action to perform, either 'stake' or 'unstake'.
- * @param {string[]} appPrivateKeys - Array of app private keys to process.
- * @returns {Promise<boolean>} Returns true if all actions are successful, false otherwise.
- */
-async function handleAppStakeAction(action: 'stake' | 'unstake', appPrivateKeys: string[]) {
-    console.log(`Handling ${action}s`);
 
-    const responses: {
-        address: string,
-        response: string,
-        success: boolean
-    }[] = [];
+        for (let i = 0; i < oldPrivateKeys.length; i += STAKE_BATCH_SIZE) {
+            const oldAppStakeKeysBatch = oldPrivateKeys.slice(i, i + STAKE_BATCH_SIZE);
+            const newAppStakeKeysBatch = newAppPrivateKeysPath.slice(i, i + STAKE_BATCH_SIZE);
 
-    const poktActionFuncWithRetry = action === 'stake' ? appStakeRetry : appUnstakeRetry;
+            const batchResults = await Promise.allSettled(oldAppStakeKeysBatch.map((addr, i) => sendAppStakeTransfer(addr, newAppStakeKeysBatch[i])));
 
-    for (let i = 0; i < appPrivateKeys.length; i += STAKE_BATCH_SIZE) {
-        const batch = appPrivateKeys.slice(i, i + STAKE_BATCH_SIZE);
-        const batchResults = await Promise.allSettled(batch.map(addr => poktActionFuncWithRetry(addr)));
-
-        for (let j = 0; j < batchResults.length; j++) {
-            const result = batchResults[j];
-            if (result.status === 'fulfilled') {
-                const responseValue = (result as PromiseFulfilledResult<string>).value;
-                responses.push({
-                    address: batch[j],
-                    response: responseValue,
-                    success: true,
-                });
-            } else {
-                // promise rejected, likely from an exception
-                responses.push({
-                    address: batch[j],
-                    response: (result as PromiseRejectedResult).reason.toString(),
-                    success: false
-                });
+            for (let j = 0; j < batchResults.length; j++) {
+                const result = batchResults[j];
+                if (result.status === 'fulfilled') {
+                    const responseValue = (result as PromiseFulfilledResult<string>).value;
+                    responses.push({
+                        response: responseValue,
+                        success: true,
+                    });
+                } else {
+                    // promise rejected, likely from an exception
+                    responses.push({
+                        response: (result as PromiseRejectedResult).reason.toString(),
+                        success: false
+                    });
+                }
             }
+        }
+
+        // Create the csv file for output
+        let csvContent = 'address,response,success\n';
+        for (const {response, success} of responses) {
+            csvContent += `${response},${success}\n`;
+        }
+        const outputFileName = `${new Date().toISOString()}-app_transfer-results.csv`.replace(/:/g, "_");
+        const outputPath = Path.join(__dirname, "../", "output", outputFileName);
+        fs.writeFileSync(outputPath, csvContent, 'utf-8');
+        console.log(`Results saved to ${outputPath}`);
+
+        return !responses.find(s => !s.success)
+    }
+
+    /**
+     * Checks if the given file path is valid and accessible.
+     *
+     * @param {string} filePath - Path to the file.
+     * @returns {boolean} True if the file is accessible, otherwise false.
+     */
+    function isValidFilePath(filePath: string): boolean {
+        try {
+            fs.accessSync(filePath);
+            return true;
+        } catch (error) {
+            return false;
         }
     }
 
-    // Create the csv file for output
-    let csvContent = 'address,response,success\n';
-    for (const {address, response, success} of responses) {
-        csvContent += `${address},${response},${success}\n`;
-    }
-    const outputFileName = `${new Date().toISOString()}-${action}-results.csv`;
-    const outputPath = Path.join(__dirname, "../", "output", outputFileName);
-    fs.writeFileSync(outputPath, csvContent, 'utf-8');
-    console.log(`Results saved to ${outputPath}`);
-
-    return !responses.find(s=> !s.success)
-}
-
-
-/**
- * Prompts the user with a question and waits for the answer.
- *
- * @param {string} question - The question to ask.
- * @returns {Promise<string>} A promise that resolves to the user's answer.
- */
-function askQuestion(question: string): Promise<string> {
-    return new Promise((resolve) => {
-        rl.question(question, (answer) => {
-            resolve(answer);
-        });
-    });
-}
-
-/**
- * Checks if the given file path is valid and accessible.
- *
- * @param {string} filePath - Path to the file.
- * @returns {boolean} True if the file is accessible, otherwise false.
- */
-function isValidFilePath(filePath: string): boolean {
-    try {
-        fs.accessSync(filePath);
+    /**
+     * Validates the content of a CSV containing private keys.
+     *
+     * @param {string[]} privateKeys - Array of strings from the CSV, where the first element is expected to be the header.
+     * @returns {boolean} True if the CSV is valid, otherwise false.
+     */
+    function isValidCsv(privateKeys: string[]): boolean {
+        const header = privateKeys[0];
+        if (header != "privateKey") {
+            console.error('malformed addreses.csv header');
+            return false;
+        }
+        const invalidAddresses = privateKeys.slice(1).filter(key => key.length !== 128);
+        if (invalidAddresses.length > 0) {
+            console.error('Invalid addresses:', invalidAddresses);
+            return false;
+        }
+        if (privateKeys.slice(1).length > 100) {
+            console.error('Avoid batch sending to more than 100 to, wait another 15 minutes and try another 100');
+            return false;
+        }
         return true;
-    } catch (error) {
-        return false;
-    }
-}
-
-/**
- * Validates the content of a CSV containing private keys.
- *
- * @param {string[]} privateKeys - Array of strings from the CSV, where the first element is expected to be the header.
- * @returns {boolean} True if the CSV is valid, otherwise false.
- */
-function isValidCsv(privateKeys: string[]): boolean {
-    const header = privateKeys[0];
-    if (header != "privateKey") {
-        console.error('malformed addreses.csv header');
-        return false;
-    }
-    const invalidAddresses = privateKeys.slice(1).filter(key => key.length !== 128);
-    if (invalidAddresses.length > 0) {
-        console.error('Invalid addresses:', invalidAddresses);
-        return false;
-    }
-    if(privateKeys.slice(1).length > 100) {
-        console.error('Avoid batch sending to more than 100 to, wait another 15 minutes and try another 100');
-        return false;
-    }
-    return true;
-}
-
-/**
- * Extracts and validates app private keys from a CSV file.
- *
- * @param {string} filePath - Path to the CSV file.
- * @returns {string[] | undefined} Array of validated private keys, or throws an exception if the CSV is not valid.
- */
-function getAppPrivateKeysFromCSV(filePath: string): string[] {
-    const receiverData = fs.readFileSync(filePath, 'utf-8');
-    const receiverAddressesFile = receiverData.split('\n').map(line => line.trim());
-
-    if (!isValidCsv(receiverAddressesFile)) {
-        throw new Error(`malformed CSV for app keys: ${filePath}`)
     }
 
-    return receiverAddressesFile.slice(1);
+    /**
+     * Extracts and validates app private keys from a CSV file.
+     *
+     * @param {string} filePath - Path to the CSV file.
+     * @returns {string[] | undefined} Array of validated private keys, or throws an exception if the CSV is not valid.
+     */
+    function getAppPrivateKeysFromCSV(filePath: string): string[] {
+        const receiverData = fs.readFileSync(filePath, 'utf-8');
+        const receiverAddressesFile = receiverData.split('\n').map(line => line.trim());
+
+        if (!isValidCsv(receiverAddressesFile)) {
+            throw new Error(`malformed CSV for app keys: ${filePath}`)
+        }
+
+        return receiverAddressesFile.slice(1).filter(s => s.length == 128);
+    }
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,120 +58,119 @@ async function main() {
     // handle stakes
     if (!await handleAppStakeTransfers(unstakePrivateKeys, unstakePrivateKeys)) {
         throw new Error("Failed to stake all apps, try running the script again!")
-
-        console.log("App stakes successfully rotated")
-        rl.close()
     }
+    console.log("App stakes successfully rotated")
+    rl.close()
+}
 
-    /**
-     * Handles the app stake transfers
-     * Processes the keys in batches and generates a CSV report of the results.
-     *
-     * @param {string[]} oldPrivateKeys - Array of app private keys to transfer from
-     * @param {string[]} newPrivateKeys - Array of app private keys to transfer to
-     * @returns {Promise<boolean>} Returns true if all actions are successful, false otherwise.
-     */
-    async function handleAppStakeTransfers(oldPrivateKeys: string[], newPrivateKeys: string[]) {
+/**
+ * Handles the app stake transfers
+ * Processes the keys in batches and generates a CSV report of the results.
+ *
+ * @param {string[]} oldPrivateKeys - Array of app private keys to transfer from
+ * @param {string[]} newPrivateKeys - Array of app private keys to transfer to
+ * @returns {Promise<boolean>} Returns true if all actions are successful, false otherwise.
+ */
+async function handleAppStakeTransfers(oldPrivateKeys: string[], newPrivateKeys: string[]) {
 
-        const responses: {
-            response: string,
-            success: boolean
-        }[] = [];
+    const responses: {
+        response: string,
+        success: boolean
+    }[] = [];
 
 
-        for (let i = 0; i < oldPrivateKeys.length; i += STAKE_BATCH_SIZE) {
-            const oldAppStakeKeysBatch = oldPrivateKeys.slice(i, i + STAKE_BATCH_SIZE);
-            const newAppStakeKeysBatch = newAppPrivateKeysPath.slice(i, i + STAKE_BATCH_SIZE);
+    for (let i = 0; i < oldPrivateKeys.length; i += STAKE_BATCH_SIZE) {
+        const oldAppStakeKeysBatch = oldPrivateKeys.slice(i, i + STAKE_BATCH_SIZE);
+        const newAppStakeKeysBatch = newAppPrivateKeysPath.slice(i, i + STAKE_BATCH_SIZE);
 
-            const batchResults = await Promise.allSettled(oldAppStakeKeysBatch.map((addr, i) => sendAppStakeTransfer(addr, newAppStakeKeysBatch[i])));
+        const batchResults = await Promise.allSettled(oldAppStakeKeysBatch.map((addr, i) => sendAppStakeTransfer(addr, newAppStakeKeysBatch[i])));
 
-            for (let j = 0; j < batchResults.length; j++) {
-                const result = batchResults[j];
-                if (result.status === 'fulfilled') {
-                    const responseValue = (result as PromiseFulfilledResult<string>).value;
-                    responses.push({
-                        response: responseValue,
-                        success: true,
-                    });
-                } else {
-                    // promise rejected, likely from an exception
-                    responses.push({
-                        response: (result as PromiseRejectedResult).reason.toString(),
-                        success: false
-                    });
-                }
+        for (let j = 0; j < batchResults.length; j++) {
+            const result = batchResults[j];
+            if (result.status === 'fulfilled') {
+                const responseValue = (result as PromiseFulfilledResult<string>).value;
+                responses.push({
+                    response: responseValue,
+                    success: true,
+                });
+            } else {
+                // promise rejected, likely from an exception
+                responses.push({
+                    response: (result as PromiseRejectedResult).reason.toString(),
+                    success: false
+                });
             }
         }
-
-        // Create the csv file for output
-        let csvContent = 'address,response,success\n';
-        for (const {response, success} of responses) {
-            csvContent += `${response},${success}\n`;
-        }
-        const outputFileName = `${new Date().toISOString()}-app_transfer-results.csv`.replace(/:/g, "_");
-        const outputPath = Path.join(__dirname, "../", "output", outputFileName);
-        fs.writeFileSync(outputPath, csvContent, 'utf-8');
-        console.log(`Results saved to ${outputPath}`);
-
-        return !responses.find(s => !s.success)
     }
 
-    /**
-     * Checks if the given file path is valid and accessible.
-     *
-     * @param {string} filePath - Path to the file.
-     * @returns {boolean} True if the file is accessible, otherwise false.
-     */
-    function isValidFilePath(filePath: string): boolean {
-        try {
-            fs.accessSync(filePath);
-            return true;
-        } catch (error) {
-            return false;
-        }
+    // Create the csv file for output
+    let csvContent = 'address,response,success\n';
+    for (const {response, success} of responses) {
+        csvContent += `${response},${success}\n`;
     }
+    const outputFileName = `${new Date().toISOString()}-app_transfer-results.csv`.replace(/:/g, "_");
+    const outputPath = Path.join(__dirname, "../", "output", outputFileName);
+    fs.writeFileSync(outputPath, csvContent, 'utf-8');
+    console.log(`Results saved to ${outputPath}`);
 
-    /**
-     * Validates the content of a CSV containing private keys.
-     *
-     * @param {string[]} privateKeys - Array of strings from the CSV, where the first element is expected to be the header.
-     * @returns {boolean} True if the CSV is valid, otherwise false.
-     */
-    function isValidCsv(privateKeys: string[]): boolean {
-        const header = privateKeys[0];
-        if (header != "privateKey") {
-            console.error('malformed addreses.csv header');
-            return false;
-        }
-        const invalidAddresses = privateKeys.slice(1).filter(key => key.length !== 128);
-        if (invalidAddresses.length > 0) {
-            console.error('Invalid addresses:', invalidAddresses);
-            return false;
-        }
-        if (privateKeys.slice(1).length > 100) {
-            console.error('Avoid batch sending to more than 100 to, wait another 15 minutes and try another 100');
-            return false;
-        }
+    return !responses.find(s => !s.success)
+}
+
+/**
+ * Checks if the given file path is valid and accessible.
+ *
+ * @param {string} filePath - Path to the file.
+ * @returns {boolean} True if the file is accessible, otherwise false.
+ */
+function isValidFilePath(filePath: string): boolean {
+    try {
+        fs.accessSync(filePath);
         return true;
-    }
-
-    /**
-     * Extracts and validates app private keys from a CSV file.
-     *
-     * @param {string} filePath - Path to the CSV file.
-     * @returns {string[] | undefined} Array of validated private keys, or throws an exception if the CSV is not valid.
-     */
-    function getAppPrivateKeysFromCSV(filePath: string): string[] {
-        const receiverData = fs.readFileSync(filePath, 'utf-8');
-        const receiverAddressesFile = receiverData.split('\n').map(line => line.trim());
-
-        if (!isValidCsv(receiverAddressesFile)) {
-            throw new Error(`malformed CSV for app keys: ${filePath}`)
-        }
-
-        return receiverAddressesFile.slice(1).filter(s => s.length == 128);
+    } catch (error) {
+        return false;
     }
 }
+
+/**
+ * Validates the content of a CSV containing private keys.
+ *
+ * @param {string[]} privateKeys - Array of strings from the CSV, where the first element is expected to be the header.
+ * @returns {boolean} True if the CSV is valid, otherwise false.
+ */
+function isValidCsv(privateKeys: string[]): boolean {
+    const header = privateKeys[0];
+    if (header != "privateKey") {
+        console.error('malformed addreses.csv header');
+        return false;
+    }
+    const invalidAddresses = privateKeys.slice(1).filter(key => key.length !== 128);
+    if (invalidAddresses.length > 0) {
+        console.error('Invalid addresses:', invalidAddresses);
+        return false;
+    }
+    if (privateKeys.slice(1).length > 100) {
+        console.error('Avoid batch sending to more than 100 to, wait another 15 minutes and try another 100');
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Extracts and validates app private keys from a CSV file.
+ *
+ * @param {string} filePath - Path to the CSV file.
+ * @returns {string[] | undefined} Array of validated private keys, or throws an exception if the CSV is not valid.
+ */
+function getAppPrivateKeysFromCSV(filePath: string): string[] {
+    const receiverData = fs.readFileSync(filePath, 'utf-8');
+    const receiverAddressesFile = receiverData.split('\n').map(line => line.trim());
+
+    if (!isValidCsv(receiverAddressesFile)) {
+        throw new Error(`malformed CSV for app keys: ${filePath}`)
+    }
+    return receiverAddressesFile.slice(1).filter(s => s.length == 128);
+}
+
 
 main().catch((error) => {
     console.error('An error occurred:', error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,15 +32,15 @@ async function main() {
         }
     }
 
-    const unstakePrivateKeys = getAppPrivateKeysFromCSV(oldAppPrivateKeysPath)
+    const oldAppStakePrivateKeys = getAppPrivateKeysFromCSV(oldAppPrivateKeysPath)
     const newAppStakePrivateKeys = getAppPrivateKeysFromCSV(newAppPrivateKeysPath)
 
-    if (unstakePrivateKeys.length != newAppStakePrivateKeys.length) {
-        throw new Error(`${unstakePrivateKeys.length} old app stakes does not match the replacement of ${newAppStakePrivateKeys.length} new app stakes`)
+    if (oldAppStakePrivateKeys.length != newAppStakePrivateKeys.length) {
+        throw new Error(`${oldAppStakePrivateKeys.length} old app stakes does not match the replacement of ${newAppStakePrivateKeys.length} new app stakes`)
     }
 
     console.log('')
-    console.log(`App stakes count being rotated: ${unstakePrivateKeys.length}`)
+    console.log(`App stakes count being rotated: ${oldAppStakePrivateKeys.length}`)
     console.log(`RPC Provider: ${rpcProviderUrl}`)
     console.log('')
 
@@ -57,7 +57,7 @@ async function main() {
     }));
 
     // handle stakes
-    if (!await handleAppStakeTransfers(unstakePrivateKeys, unstakePrivateKeys)) {
+    if (!await handleAppStakeTransfers(oldAppStakePrivateKeys, newAppStakePrivateKeys)) {
         throw new Error("Failed to stake all apps, try running the script again!")
     }
     console.log("App stakes successfully rotated")
@@ -84,9 +84,9 @@ async function handleAppStakeTransfers(oldPrivateKeys: string[], newPrivateKeys:
 
     for (let i = 0; i < oldPrivateKeys.length; i += STAKE_BATCH_SIZE) {
         const oldAppStakeKeysBatch = oldPrivateKeys.slice(i, i + STAKE_BATCH_SIZE);
-        const newAppStakeKeysBatch = newAppPrivateKeysPath.slice(i, i + STAKE_BATCH_SIZE);
+        const newAppStakeKeysBatch = newPrivateKeys.slice(i, i + STAKE_BATCH_SIZE);
 
-        const batchResults = await Promise.allSettled(oldAppStakeKeysBatch.map((addr, i) => sendAppStakeTransfer(addr, newAppStakeKeysBatch[i])));
+        const batchResults = await Promise.allSettled(oldAppStakeKeysBatch.map((oldPrivateKey, i) => sendAppStakeTransfer(oldPrivateKey, newAppStakeKeysBatch[i])));
 
         for (let j = 0; j < batchResults.length; j++) {
             const result = batchResults[j];

--- a/src/pokt/appStakeTxs.ts
+++ b/src/pokt/appStakeTxs.ts
@@ -21,7 +21,7 @@ export async function sendAppStakeTransfer(oldAppPrivateKey: string, newAppPriva
     });
 
     const newAppPrivateKeySigner = await KeyManager.fromPrivateKey(newAppPrivateKey)
-    console.log(`Attempting to transfer app: ${oldAppPrivateKeySigner.getAddress()} to ${newAppPrivateKeySigner.getPublicKey()}`);
+    console.log(`Attempting to transfer app: ${oldAppPrivateKeySigner.getAddress()} to ${newAppPrivateKeySigner.getAddress()}`);
     const actionMsg = transactionBuilder.appTransfer({
         appPubKey: newAppPrivateKeySigner.getPublicKey(),
     });

--- a/src/pokt/appStakeTxs.ts
+++ b/src/pokt/appStakeTxs.ts
@@ -6,24 +6,24 @@ import { getPoktProvider } from "../di";
 /**
  * Tries to perform a app transfer with retries
  *
- * @param {string} appPrivateKey - The private key for the app.
- * @param {string} newAppPrivateKey - new app private key if using app transfer
+ * @param {string} oldAppPrivateKey - The private key for the old app key
+ * @param {string} newAppPrivateKey - The private key for the new app key being rotated.
  * @param {number} [retryAttempts=10] - The number of times to retry the action if it fails.
  * @returns {Promise<string>} The transaction hash if successful, 'Failed' otherwise.
  */
-export async function sendAppStakeTransfer(appPrivateKey: string,  newAppPrivateKey: string, retryAttempts = 10): Promise<string> {
-    const signer = await KeyManager.fromPrivateKey(appPrivateKey);
+export async function sendAppStakeTransfer(oldAppPrivateKey: string, newAppPrivateKey: string, retryAttempts = 10): Promise<string> {
+    const oldAppPrivateKeySigner = await KeyManager.fromPrivateKey(oldAppPrivateKey);
 
     const transactionBuilder = new TransactionBuilder({
         provider: getPoktProvider(),
-        signer,
+        signer: oldAppPrivateKeySigner,
         chainID: process.env.chainId as ChainID || "mainnet"
     });
 
-    const transferAppKM = await KeyManager.fromPrivateKey(newAppPrivateKey)
-    console.log(`Attempting to transfer app: ${signer.getAddress()} to ${transferAppKM.getPublicKey()}`);
+    const newAppPrivateKeySigner = await KeyManager.fromPrivateKey(newAppPrivateKey)
+    console.log(`Attempting to transfer app: ${oldAppPrivateKeySigner.getAddress()} to ${newAppPrivateKeySigner.getPublicKey()}`);
     const actionMsg = transactionBuilder.appTransfer({
-        appPubKey: transferAppKM.getPublicKey(),
+        appPubKey: newAppPrivateKeySigner.getPublicKey(),
     });
 
     let error: any;


### PR DESCRIPTION
This PR removes the old app stake rotation capabilities and replaces them with the AppTransfer functionality. 

As well, it includes a new script to generate app stake keys with `npm run generate-new-keys`